### PR TITLE
Dev-pedrod/fixes

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -96,6 +96,6 @@
       <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
-    
+
   </dependencies>
 </project>

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -20,42 +20,41 @@
   <artifactId>user-service</artifactId>
   <name>User Service</name>
   <dependencies>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.vaadin.external.google</groupId>
       <artifactId>android-json</artifactId>
       <version>0.0.20131108.vaadin1</version>
       <scope>compile</scope>
     </dependency>
-      <dependency>
-          <groupId>org.springframework.security</groupId>
-          <artifactId>spring-security-crypto</artifactId>
-      </dependency>
+
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
@@ -78,21 +77,25 @@
       <artifactId>firebase-admin</artifactId>
       <version>6.10.0</version>
     </dependency>
+
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
       <version>1.96.0</version>
     </dependency>
+
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>1.30.4</version>
     </dependency>
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
+    
   </dependencies>
 </project>

--- a/user-service/src/main/java/guc/bttsBtngan/user/services/UserRepository.java
+++ b/user-service/src/main/java/guc/bttsBtngan/user/services/UserRepository.java
@@ -11,8 +11,8 @@ import java.util.Optional;
 // to perform CRUD operations on user entity
 @Repository
 public interface UserRepository extends JpaRepository<UserUserInteraction, String> {
-    @Query(value = "SELECT s FROM UserUserInteraction s WHERE s.email = ?1")
-    Optional<UserUserInteraction> findByEmail(String email);
+    //@Query(value = "SELECT s FROM UserUserInteraction s WHERE s.email = ?1")
+    Optional<UserUserInteraction> findByEmailIgnoreCase(String email);
 
     @Query(value = "SELECT s FROM UserUserInteraction s WHERE s.photoRef = ?1")
     Optional<UserUserInteraction> findByphotoRef(String photoRef);

--- a/user-service/src/main/java/guc/bttsBtngan/user/services/UserRepository.java
+++ b/user-service/src/main/java/guc/bttsBtngan/user/services/UserRepository.java
@@ -17,6 +17,6 @@ public interface UserRepository extends JpaRepository<UserUserInteraction, Strin
     @Query(value = "SELECT s FROM UserUserInteraction s WHERE s.photoRef = ?1")
     Optional<UserUserInteraction> findByphotoRef(String photoRef);
 
-    @Query(value = "SELECT s FROM UserUserInteraction s WHERE s.username = ?1")
-    Optional<UserUserInteraction> findByUsername(String username);
+    //@Query(value = "SELECT s FROM UserUserInteraction s WHERE s.username = ?1")
+    Optional<UserUserInteraction> findByUsernameIgnoreCase(String username);
 }

--- a/user-service/src/main/java/guc/bttsBtngan/user/services/UserUserService.java
+++ b/user-service/src/main/java/guc/bttsBtngan/user/services/UserUserService.java
@@ -82,7 +82,7 @@ public class UserUserService {
         }
 
         // check if the username already exists
-        Optional<UserUserInteraction> username = userRepository.findByUsername(user.getusername());
+        Optional<UserUserInteraction> username = userRepository.findByUsernameIgnoreCase(user.getusername());
         if (username.isPresent()) {
             // if the user username already exists
             throw new IllegalStateException("Username already exists");

--- a/user-service/src/main/java/guc/bttsBtngan/user/services/UserUserService.java
+++ b/user-service/src/main/java/guc/bttsBtngan/user/services/UserUserService.java
@@ -69,7 +69,7 @@ public class UserUserService {
             throw new IllegalArgumentException("Username, email and password cannot be empty");
         }
         // check if the email is already registered
-        Optional<UserUserInteraction> email = userRepository.findByEmail(user.getEmail());
+        Optional<UserUserInteraction> email = userRepository.findByEmailIgnoreCase(user.getEmail());
         if (email.isPresent()) {
             // if the user email already exists
             throw new IllegalStateException("Email already exists");
@@ -139,7 +139,7 @@ public class UserUserService {
         }
         // if email is not null, not empty & not the same as the current email & not already have been taken
         if(email != null && email.length() > 0 && !Objects.equals(email, user.getEmail())){
-            Optional<UserUserInteraction> emailExists = userRepository.findByEmail(email);
+            Optional<UserUserInteraction> emailExists = userRepository.findByEmailIgnoreCase(email);
             // check if the email is already registered
             if (!emailExists.isPresent()) {
                 user.setEmail(email);

--- a/user-service/src/test/java/guc/bttsBtngan/user/services/UserUserServiceTest.java
+++ b/user-service/src/test/java/guc/bttsBtngan/user/services/UserUserServiceTest.java
@@ -159,7 +159,7 @@ class UserUserServiceTest {
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
         when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
-        when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByUsernameIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
 
         UserUserInteraction userUserInteraction4 = new UserUserInteraction();
@@ -205,7 +205,7 @@ class UserUserServiceTest {
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction2);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
         when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(Optional.empty());
-        when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByUsernameIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult1);
 
         UserUserInteraction userUserInteraction3 = new UserUserInteraction();
@@ -217,7 +217,7 @@ class UserUserServiceTest {
         userUserInteraction3.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction3));
         verify(this.userRepository).findByEmailIgnoreCase((String) any());
-        verify(this.userRepository).findByUsername((String) any());
+        verify(this.userRepository).findByUsernameIgnoreCase((String) any());
     }
 
     /**
@@ -261,7 +261,7 @@ class UserUserServiceTest {
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
         when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
-        when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByUsernameIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
         UserUserInteraction userUserInteraction4 = mock(UserUserInteraction.class);
         when(userUserInteraction4.getPassword()).thenReturn("Pass123");
@@ -333,7 +333,7 @@ class UserUserServiceTest {
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
         when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
-        when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByUsernameIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
         UserUserInteraction userUserInteraction4 = mock(UserUserInteraction.class);
         when(userUserInteraction4.getPassword()).thenThrow(new IllegalArgumentException("janedoe"));
@@ -395,7 +395,7 @@ class UserUserServiceTest {
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction2);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
         when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(Optional.empty());
-        when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByUsernameIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult1);
         UserUserInteraction userUserInteraction3 = mock(UserUserInteraction.class);
         when(userUserInteraction3.getPassword()).thenReturn("Pass123");
@@ -415,7 +415,7 @@ class UserUserServiceTest {
         userUserInteraction3.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction3));
         verify(this.userRepository).findByEmailIgnoreCase((String) any());
-        verify(this.userRepository).findByUsername((String) any());
+        verify(this.userRepository).findByUsernameIgnoreCase((String) any());
         verify(userUserInteraction3, atLeast(1)).getEmail();
         verify(userUserInteraction3).getPassword();
         verify(userUserInteraction3, atLeast(1)).getusername();

--- a/user-service/src/test/java/guc/bttsBtngan/user/services/UserUserServiceTest.java
+++ b/user-service/src/test/java/guc/bttsBtngan/user/services/UserUserServiceTest.java
@@ -158,7 +158,7 @@ class UserUserServiceTest {
         userUserInteraction3.setusername("janedoe");
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
 
@@ -170,7 +170,7 @@ class UserUserServiceTest {
         userUserInteraction4.setid("42");
         userUserInteraction4.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction4));
-        verify(this.userRepository).findByEmail((String) any());
+        verify(this.userRepository).findByEmailIgnoreCase((String) any());
     }
 
     /**
@@ -204,7 +204,7 @@ class UserUserServiceTest {
         userUserInteraction2.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction2);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(Optional.empty());
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(Optional.empty());
         when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult1);
 
@@ -216,7 +216,7 @@ class UserUserServiceTest {
         userUserInteraction3.setid("42");
         userUserInteraction3.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction3));
-        verify(this.userRepository).findByEmail((String) any());
+        verify(this.userRepository).findByEmailIgnoreCase((String) any());
         verify(this.userRepository).findByUsername((String) any());
     }
 
@@ -260,7 +260,7 @@ class UserUserServiceTest {
         userUserInteraction3.setusername("janedoe");
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
         UserUserInteraction userUserInteraction4 = mock(UserUserInteraction.class);
@@ -280,7 +280,7 @@ class UserUserServiceTest {
         userUserInteraction4.setid("42");
         userUserInteraction4.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction4));
-        verify(this.userRepository).findByEmail((String) any());
+        verify(this.userRepository).findByEmailIgnoreCase((String) any());
         verify(userUserInteraction4, atLeast(1)).getEmail();
         verify(userUserInteraction4).getPassword();
         verify(userUserInteraction4).getusername();
@@ -332,7 +332,7 @@ class UserUserServiceTest {
         userUserInteraction3.setusername("janedoe");
         Optional<UserUserInteraction> ofResult2 = Optional.of(userUserInteraction3);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult2);
         UserUserInteraction userUserInteraction4 = mock(UserUserInteraction.class);
@@ -394,7 +394,7 @@ class UserUserServiceTest {
         userUserInteraction2.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction2);
         when(this.userRepository.save((UserUserInteraction) any())).thenReturn(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(Optional.empty());
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(Optional.empty());
         when(this.userRepository.findByUsername((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult1);
         UserUserInteraction userUserInteraction3 = mock(UserUserInteraction.class);
@@ -414,7 +414,7 @@ class UserUserServiceTest {
         userUserInteraction3.setid("42");
         userUserInteraction3.setusername("janedoe");
         assertThrows(IllegalStateException.class, () -> this.userUserService.registerUser(userUserInteraction3));
-        verify(this.userRepository).findByEmail((String) any());
+        verify(this.userRepository).findByEmailIgnoreCase((String) any());
         verify(this.userRepository).findByUsername((String) any());
         verify(userUserInteraction3, atLeast(1)).getEmail();
         verify(userUserInteraction3).getPassword();
@@ -478,7 +478,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", "pass", "pass",
@@ -526,7 +526,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalArgumentException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", "pass", "pass",
@@ -574,12 +574,12 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", "pass", "pass",
                         new MockMultipartFile("Name", new ByteArrayInputStream("AAAAAAAA".getBytes("UTF-8")))));
-        verify(this.userRepository).findByEmail((String) any());
+        verify(this.userRepository).findByEmailIgnoreCase((String) any());
         verify(this.userRepository).findById((String) any());
         verify(userUserInteraction).getEmail();
         verify(userUserInteraction).getusername();
@@ -622,7 +622,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", "pass", "pass",
@@ -655,7 +655,7 @@ class UserUserServiceTest {
         userUserInteraction.setid("42");
         userUserInteraction.setusername("janedoe");
         Optional<UserUserInteraction> ofResult = Optional.of(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(null);
         UserUserInteraction userUserInteraction1 = mock(UserUserInteraction.class);
         when(userUserInteraction1.getPassword()).thenReturn("pass");
@@ -690,7 +690,7 @@ class UserUserServiceTest {
         userUserInteraction.setid("42");
         userUserInteraction.setusername("janedoe");
         Optional<UserUserInteraction> ofResult = Optional.of(userUserInteraction);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult);
         when(this.userRepository.findById((String) any())).thenReturn(Optional.empty());
         UserUserInteraction userUserInteraction1 = mock(UserUserInteraction.class);
         when(userUserInteraction1.getPassword()).thenReturn("pass");
@@ -751,7 +751,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class, () -> this.userUserService.updateUser("42", null, "jane.doe@example.org",
                 "pass", "pass", new MockMultipartFile("Name", new ByteArrayInputStream("AAAAAAAA".getBytes("UTF-8")))));
@@ -797,7 +797,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class, () -> this.userUserService.updateUser("42", "", "jane.doe@example.org",
                 "pass", "pass", new MockMultipartFile("Name", new ByteArrayInputStream("AAAAAAAA".getBytes("UTF-8")))));
@@ -843,7 +843,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class, () -> this.userUserService.updateUser("42", "janedoe", null, "pass",
                 "pass", new MockMultipartFile("Name", new ByteArrayInputStream("AAAAAAAA".getBytes("UTF-8")))));
@@ -889,7 +889,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class, () -> this.userUserService.updateUser("42", "janedoe", "", "pass",
                 "pass", new MockMultipartFile("Name", new ByteArrayInputStream("AAAAAAAA".getBytes("UTF-8")))));
@@ -935,7 +935,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", null, "pass",
@@ -982,7 +982,7 @@ class UserUserServiceTest {
         userUserInteraction1.setid("42");
         userUserInteraction1.setusername("janedoe");
         Optional<UserUserInteraction> ofResult1 = Optional.of(userUserInteraction1);
-        when(this.userRepository.findByEmail((String) any())).thenReturn(ofResult1);
+        when(this.userRepository.findByEmailIgnoreCase((String) any())).thenReturn(ofResult1);
         when(this.userRepository.findById((String) any())).thenReturn(ofResult);
         assertThrows(IllegalStateException.class,
                 () -> this.userUserService.updateUser("42", "janedoe", "jane.doe@example.org", "", "pass",


### PR DESCRIPTION
Users can create account with the same email and username

Example:
 ```
User 1:
{
	"username" : "Dev-pedrod",
	"password": "Pedro123",
	"email" : "Dev-pedrod@gmail.com"
}

User 2:
{
	"username" : "dev-pedrod",
	"password": "Pedro123",
	"email" : "dev-pedrod@gmail.com"
}
 ```

I added "IgnoreCase" to avoid this

![image](https://user-images.githubusercontent.com/86006066/173257282-3056e5f2-7cb0-45e6-aa83-9dc4ced4ca1f.png)

You can delete the queries if you want
